### PR TITLE
Fixes mapping of urlscan

### DIFF
--- a/src/main/java/me/vighnesh/api/virustotal/dao/URLScan.java
+++ b/src/main/java/me/vighnesh/api/virustotal/dao/URLScan.java
@@ -18,6 +18,7 @@ import com.google.gson.annotations.SerializedName;
  */
 public class URLScan {
 
+    @SerializedName("detected")
     @Expose
     private boolean malicious;
     @SerializedName("result")


### PR DESCRIPTION
Hi,

while using the api I noticed, that the UrlScanReport did not map the malicious attribute.
I fixed it.